### PR TITLE
V0.5.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 ## [WIP] 0.5.0 / 2017-December-??
 
 * Routes
+  * [BREAKING CHANGE] Matcher now returns potentially-updated request, or `nil`
   * [BREAKING CHANGE] Route handler now has the same arity as Ring handler
     * Path-params associated in request map under respective keys
     * This allows Ring middleware to be applied to route handlers

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,15 +6,17 @@
 
 ## [WIP] 0.5.0 / 2017-December-??
 
-* [TODO - BREAKING CHANGE] Use arity-1 route handler functions
-  * Params associated in the request map under the `:path-params` key
-  * This allows Ring middleware to be applied to route handlers
-* [TODO - BREAKING CHANGE] Rename the abstraction uri-template to path
-* [TODO] Allow to construct a URI from URI template and params map
-* [TODO] Add a middleware to add route to the request map
-* [TODO] Add support for fetching/rendering static files
-  * Rendering should be configurable (default: fn that returns file-content as body)
-* [TODO] Documentation for routes (keys other than essential ones)
+* Routes
+  * [BREAKING CHANGE] Route handler now has the same arity as Ring handler
+    * Path-params associated in request map under respective keys
+    * This allows Ring middleware to be applied to route handlers
+  * [BREAKING CHANGE] Drop `ring-handler-middleware`
+  * [TODO - BREAKING CHANGE] Rename the abstraction uri-template to path
+  * [TODO] Allow to construct a URI from URI template and params map
+  * [TODO] Add a middleware to add route to the request map
+  * [TODO] Add support for fetching/rendering static files
+    * Rendering should be configurable (default: fn that returns file-content as body)
+  * [TODO] Documentation for routes (keys other than essential ones)
 
 
 ## 0.4.0 / 2016-October-13

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,11 @@
 
 ## TODO
 
+* [TODO - BREAKING CHANGE] Rename the abstraction uri-template to path
+* [TODO] Add a middleware to add route to the request map
+* [TODO] Allow to construct a URI from URI template and params map
+  - Account for partial and nested URI templates
+
 
 ## [WIP] 0.5.0 / 2017-December-??
 
@@ -12,12 +17,9 @@
     * Path-params associated in request map under respective keys
     * This allows Ring middleware to be applied to route handlers
   * [BREAKING CHANGE] Drop `ring-handler-middleware`
-  * [TODO - BREAKING CHANGE] Rename the abstraction uri-template to path
-  * [TODO] Allow to construct a URI from URI template and params map
-  * [TODO] Add a middleware to add route to the request map
-  * [TODO] Add support for fetching/rendering static files
-    * Rendering should be configurable (default: fn that returns file-content as body)
-  * [TODO] Documentation for routes (keys other than essential ones)
+* Documentation
+  * Fetching/rendering static files or classpath resources using Ring middleware
+  * Documentation for routes (keys other than essential ones)
 
 
 ## 0.4.0 / 2016-October-13

--- a/README.md
+++ b/README.md
@@ -67,8 +67,10 @@ fundamental keys:
 
 #### Notes on routes
 
-* Either `:handler` or `:nested` key must be present in a route spec.
-* A successful match may return an updated request, or the same request or `nil`
+- The `:matcher` key must be present in a route spec for dispatch.
+  - In practice, other keys (e.g. `:uri`, `:method` etc.) add the `:matcher` key
+- Either `:handler` or `:nested` key must be present in a route spec.
+- A successful match may return an updated request, or the same request, or `nil`
 
 See examples below:
 
@@ -86,8 +88,14 @@ See examples below:
    {:uri "/users/:user-id*" :nested [{:uri "/jobs/"        :nested [{:method :get  :handler list-user-jobs}
                                                                     {:method :post :handler assign-job}]}
                                      {:uri "/permissions/" :method :get :handler permissions-hanler}]}
-   {:uri "/orders/:order-id/confirm/" :method :post :handler confirm-order}
-   {:uri "/health/" :handler health-status}])
+   {:uri "/orders/:order-id/confirm/" :method :post :handler confirm-order}        ; :uri is lifted over :method
+   {:uri "/health/"  :handler health-status}
+   {:uri "/static/*" :handler (-> (fn [_] {:status 400 :body "No such file"})      ; static files serving example
+                                ;; the following require Ring dependency in your project
+                                (ring.middleware.resource/wrap-resource "public")  ; render files from classpath
+                                (ring.middleware.file/wrap-file "/var/www/public") ; render files from filesystem
+                                (ring.middleware.content-type/wrap-content-type)
+                                (ring.middleware.not-modified/wrap-not-modified))}])
 
 ;; create a Ring handler from given routes
 (def ring-handler

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Clojure library for _à la carte_ (orthogonal) [Ring](https://github.com/ring-
 
 ## Usage
 
-Leiningen dependency: `[calfpath "0.4.0"]`
+Leiningen dependency: `[calfpath "0.5.0-SNAPSHOT"]`
 
 Require namespace:
 ```clojure
@@ -60,26 +60,23 @@ fundamental keys:
 
 | Key        | Required? | Description |
 |------------|-----------|-------------|
-| `:matcher` |    Yes    | Arity-1 fn: accepts request map, returns non-`nil` map on success and `nil` on failure |
-| `:nested`  |   Either  | Routes vector - match is attempted on this if matcher was successful |
-| `:handler` |   Either  | Arity-2 fn: accepts request map and params map, returns Ring response map |
+| `:matcher` |    Yes    | `(fn [request]) -> request?` returns request on success and `nil` on failure |
+| `:nested`  |   Either  | Routes vector - nested match is attempted on this if matcher was successful |
+| `:handler` |   Either  | `(fn [request]) -> response` returns Ring response map, like a Ring handler |
 
 
 #### Notes on routes
 
-* Either of `:nested` and `:handler` keys must be present in a route spec.
-* A minimal successful match result is `{}`.
-* A match result may optionally contain
-  * `:request` key to represent an updated request map
-  * `:params` key to represent a route-params map
+* Either `:handler` or `:nested` key must be present in a route spec.
+* A successful match may return an updated request, or the same request or `nil`
 
 See examples below:
 
 ```clojure
 
-;; a route handler is arity-2 fn
+;; a route-handler is arity-1 fn, like a ring-handler
 (defn list-user-jobs
-  [request {:keys [user-id]}]
+  [{:keys [user-id] :as request}]
   ...)
 
 (defn app-routes
@@ -104,14 +101,24 @@ See examples below:
 
 You need JDK 1.7 or higher during development.
 
-Running tests: `lein with-profile c17 test`
+Running tests:
 
-Running performance benchmarks: `lein with-profile c17,perf test`
+```shell
+$ lein do clean, test
+$ lein with-profile c17 test
+```
+
+Running performance benchmarks:
+
+```shell
+$ lein do clean, perf-test
+$ lein with-profile c17,perf test  # on specified Clojure version
+```
 
 
 ## License
 
-Copyright © 2015-2016 Shantanu Kumar (kumar.shantanu@gmail.com, shantanu.kumar@concur.com)
+Copyright © 2015-2017 Shantanu Kumar (kumar.shantanu@gmail.com, shantanu.kumar@concur.com)
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/perf/calfpath/perf_test.clj
+++ b/perf/calfpath/perf_test.clj
@@ -141,7 +141,7 @@
 
 
 (def calfpath-uri-routes
-  [{:uri "/user/:id/profile/:type/" :handler (fn [request {:keys [id type]}]
+  [{:uri "/user/:id/profile/:type/" :handler (fn [{:keys [id type] :as request}]
                                                (->method request
                                                  :get {:status 200
                                                        :headers {"Content-Type" "text/plain"}
@@ -149,7 +149,7 @@
                                                  :put {:status 200
                                                        :headers {"Content-Type" "text/plain"}
                                                        :body "1.2"}))}
-   {:uri "/user/:id/permissions/"   :handler (fn [request {:keys [id]}]
+   {:uri "/user/:id/permissions/"   :handler (fn [{:keys [id] :as request}]
                                                (->method request
                                                  :get {:status 200
                                                        :headers {"Content-Type" "text/plain"}
@@ -157,11 +157,11 @@
                                                  :put {:status 200
                                                        :headers {"Content-Type" "text/plain"}
                                                        :body "2.2"}))}
-   {:uri "/company/:cid/dept/:did/" :handler (fn [request {:keys [cid did]}]
+   {:uri "/company/:cid/dept/:did/" :handler (fn [{:keys [cid did] :as request}]
                                                (->put request {:status 200
                                                                :headers {"Content-Type" "text/plain"}
                                                                :body "3"}))}
-   {:uri "/this/is/a/static/route"  :handler (fn [request _]
+   {:uri "/this/is/a/static/route"  :handler (fn [request]
                                                (->put request {:status 200
                                                                :headers {"Content-Type" "text/plain"}
                                                                :body "4"}))}])

--- a/project.clj
+++ b/project.clj
@@ -20,4 +20,5 @@
              :perf {:dependencies [[compojure "1.5.2" :exclusions [[org.clojure/clojure]]]
                                    [citius    "0.2.4"]]
                     :test-paths ["perf"]
-                    :jvm-opts ^:replace ["-server" "-Xms2048m" "-Xmx2048m"]}})
+                    :jvm-opts ^:replace ["-server" "-Xms2048m" "-Xmx2048m"]}}
+  :aliases {"perf-test" ["with-profile" "c19,perf" "test"]})


### PR DESCRIPTION
- make route handler compatible with Ring handler
- drop `ring-handler-middleware` and associated API
- add path-params to request map in URI matcher